### PR TITLE
fix: update Web3Community links to `WebXDAO`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 Thank you for your pull request. Please provide a description above and review
 the requirements below.
 
-Contributors guide: https://github.com/web3community/devprotocol.xyz/blob/main/CONTRIBUTING.md
+Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
 -->
 
 <!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->
@@ -18,7 +18,7 @@ Contributors guide: https://github.com/web3community/devprotocol.xyz/blob/main/C
 **I agree to the following :-**
 
 * [ ]   Added description of the change
-* [ ]   I've read the [contributing guidelines](https://github.com/web3community/devprotocol.xyz/blob/main/CONTRIBUTING.md)
+* [ ]   I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
 * [ ]   Search previous suggestions before making a new PR, as yours may be a duplicate.
 * [ ]   I acknowledge that all my contributions will be made under the project's license.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This project and everyone participating in it is governed by a [Code of Conduct]
 
 This section guides you through submitting a bug report. Following these guidelines helps maintainers and the community understand your report 📝, reproduce the behavior 💻 💻, and find related reports. 🔎
 
-Since the new GitHub Issue forms we only suggest you to include most information possible. But you can also **Perform a [cursory search](https://github.com/web3community/devprotocol.xyz/issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+Since the new GitHub Issue forms we only suggest you to include most information possible. But you can also **Perform a [cursory search](https://github.com/WebXDAO/devprotocol.xyz/issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -22,7 +22,7 @@ Since the new GitHub Issue forms we only suggest you to include most information
 
 This section guides you through submitting an enhancement suggestion, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion 📝 and find related suggestions. 🔎
 
-Since the new GitHub Issue forms we only suggest you to include most information possible. But you can also **Perform a [cursory search](https://github.com/web3community/devprotocol.xyz/issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+Since the new GitHub Issue forms we only suggest you to include most information possible. But you can also **Perform a [cursory search](https://github.com/WebXDAO/devprotocol.xyz/issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -30,8 +30,8 @@ Since the new GitHub Issue forms we only suggest you to include most information
 
 Unsure where to begin contributing to this project? You can start by looking through these beginner-friendly issues:
 
-*   [Beginner issues](https://github.com/web3community/devprotocol.xyz/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - issues which should only require a few lines of code, and a test or two.
-*   [Help wanted issues](https://github.com/web3community/devprotocol.xyz/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) - issues which should be a bit more involved than `beginner` issues.
+*   [Beginner issues](https://github.com/WebXDAO/devprotocol.xyz/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - issues which should only require a few lines of code, and a test or two.
+*   [Help wanted issues](https://github.com/WebXDAO/devprotocol.xyz/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) - issues which should be a bit more involved than `beginner` issues.
 
 ### 📣 Pull Requests
 
@@ -42,7 +42,7 @@ The process described here has several goals:
 *   Engage the community in working toward the best possible!
 *   Enable a sustainable system for maintainers to review contributions
 
-Please follow all instructions in [the template](https://github.com/web3community/devprotocol.xyz/blob/main/.github/pull_request_template.md)
+Please follow all instructions in [the template](https://github.com/WebXDAO/devprotocol.xyz/blob/main/.github/pull_request_template.md)
 
 ## Style Guide for Git Commit Messages :memo:
 
@@ -56,12 +56,12 @@ Please follow all instructions in [the template](https://github.com/web3communit
 *   Do not end the subject line with a period.
 *   Wrap the body at *72 characters*.
 *   Use the body to explain the *what*, *why*, *vs*, and *how*.
-*   Reference [issues](https://github.com/web3community/devprotocol.xyz/issues) and [pull requests](https://github.com/web3community/devprotocol.xyz/pulls) liberally after the first line.
+*   Reference [issues](https://github.com/WebXDAO/devprotocol.xyz/issues) and [pull requests](https://github.com/WebXDAO/devprotocol.xyz/pulls) liberally after the first line.
 *   Follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines
 
 ## How to Contribute 🚀
 
-*   Please create an [issue](https://github.com/web3community/devprotocol.xyz/issues) before creating a pull request.
+*   Please create an [issue](https://github.com/WebXDAO/devprotocol.xyz/issues) before creating a pull request.
 
 *   Fork the repository and create a branch for any issue that you are working on.
 
@@ -71,7 +71,7 @@ Please follow all instructions in [the template](https://github.com/web3communit
 
 ## How to make a pull request 🤔
 
-**1.** Fork [this](https://github.com/web3community/devprotocol.xyz) repository. Click on the <a  href="https://github.com/web3community/devprotocol.xyz"><img  src="https://img.icons8.com/fluency/30/000000/code-fork.png"/></a> symbol at the top right corner.
+**1.** Fork [this](https://github.com/WebXDAO/devprotocol.xyz) repository. Click on the <a  href="https://github.com/WebXDAO/devprotocol.xyz"><img  src="https://img.icons8.com/fluency/30/000000/code-fork.png"/></a> symbol at the top right corner.
 
 **2.** Clone the forked repository.
 
@@ -139,4 +139,4 @@ After this, the project maintainers will review the changes and will merge your 
 ## 📈 Getting started
 
 *   😕 Not sure where to start? Join our community on [Discord](https://discord.gg/VwJp4KM)
-*   ✨ You can also take part in our [Community Discussions](https://github.com/web3community/devprotocol.xyz/discussions)
+*   ✨ You can also take part in our [Community Discussions](https://github.com/WebXDAO/devprotocol.xyz/discussions)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><p><a href="https://app.netlify.com/sites/devprotocol/deploys"><img src="https://img.shields.io/netlify/bddfebe4-8553-4de6-9ddb-522ce7f67842?style=flat-square&logo=netlify&color=darkcyan"></a> <a href="https://discord.gg/VwJp4KM"><img src="https://img.shields.io/discord/547215761341546497?style=flat-square&logo=discord&colorB=5865F2"></a> </p><br> <img height="70px" src="https://github.com/web3community/devprotocol.xyz/raw/main/public/assets/logo.png"><br><h1>devprotocol.xyz</h1><h5>Dev Protocol Website 2.0</h5><br><p><img src="https://user-images.githubusercontent.com/91655303/136316732-199891d1-9983-4370-b221-e972bc566d22.png" height="400"></p><p><a href="https://user-images.githubusercontent.com/91655303/136316732-199891d1-9983-4370-b221-e972bc566d22.png"></a> <a href="https://devprotocol.xyz/">View deployed version</a> · <a href="https://github.com/web3community/devprotocol.xyz/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBUG%5D+%3Cdescription%3E">Report a Bug</a></p></div>
+<div align="center"><p><a href="https://app.netlify.com/sites/devprotocol/deploys"><img src="https://img.shields.io/netlify/bddfebe4-8553-4de6-9ddb-522ce7f67842?style=flat-square&logo=netlify&color=darkcyan"></a> <a href="https://discord.gg/VwJp4KM"><img src="https://img.shields.io/discord/547215761341546497?style=flat-square&logo=discord&colorB=5865F2"></a> </p><br> <img height="70px" src="https://github.com/WebXDAO/devprotocol.xyz/raw/main/public/assets/logo.png"><br><h1>devprotocol.xyz</h1><h5>Dev Protocol Website 2.0</h5><br><p><img src="https://user-images.githubusercontent.com/91655303/136316732-199891d1-9983-4370-b221-e972bc566d22.png" height="400"></p><p><a href="https://user-images.githubusercontent.com/91655303/136316732-199891d1-9983-4370-b221-e972bc566d22.png"></a> <a href="https://devprotocol.xyz/">View deployed version</a> · <a href="https://github.com/WebXDAO/devprotocol.xyz/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBUG%5D+%3Cdescription%3E">Report a Bug</a></p></div>
 
 ## 🤓 Features
 
@@ -15,7 +15,7 @@ This website is live hosted at [devprotocol.xyz](https://devprotocol.xyz).
 
 ## 🚀 Get it running quick
 
-1.  Skip all of the rest steps and use Gitpod, which would automatically do all of this for you: [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/web3community/devprotocol.xyz)
+1.  Skip all of the rest steps and use Gitpod, which would automatically do all of this for you: [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/WebXDAO/devprotocol.xyz)
 
 2.  Make sure you have the latest version of NodeJs Installed.
 
@@ -41,12 +41,12 @@ yarn start
 
 ## ⌚ Coming Soon
 
-Updates available at: https://github.com/web3community/devprotocol.xyz/projects/1
+Updates available at: https://github.com/WebXDAO/devprotocol.xyz/projects/1
 
 ## 💖 Contributors
 
 Every contributor's efforts and time are deeply appreciated. Thank you! :smile:
 
-<a href = "https://github.com/web3community/devprotocol.xyz/graphs/contributors">
-  <img src = "https://contrib.rocks/image?repo=web3community/devprotocol.xyz"/>
+<a href = "https://github.com/WebXDAO/devprotocol.xyz/graphs/contributors">
+  <img src = "https://contrib.rocks/image?repo=WebXDAO/devprotocol.xyz"/>
 </a>

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "tailwindcss": "^3.0.7"
   },
   "description": "Dev Protocol's open-source website, built with Astro",
-  "repository": "https://github.com/web3community/devprotocol.xyz.git",
-  "author": "Web3Community",
+  "repository": "https://github.com/WebXDAO/devprotocol.xyz.git",
+  "author": "WebXDAO",
   "license": "MIT",
   "dependencies": {
     "vue3-carousel": "^0.1.30"

--- a/src/components/CommunityPartners/CommunityPartners.vue
+++ b/src/components/CommunityPartners/CommunityPartners.vue
@@ -142,9 +142,9 @@ export default {
           extraClass: "rounded-full",
         },
         {
-          name: "Web3Community",
-          image: "https://github.com/Web3Community.png",
-          link: "https://web3community.github.io",
+          name: "WebXDAO",
+          image: "https://github.com/WebXDAO.png",
+          link: "https://webxdao.github.io",
           description:
             "An Open Source Community that focuses on decentralized applications, web 3, and blockchain technologies 🚀",
           extraClass: "rounded-full",


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/web3community/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

- Update Web3Community links to `WebXDAO`.

#### Checklist

**I agree to the following :-**

* [x]   Added description of the change
* [x]   I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
* [x]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [x]   I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->


<a href="https://gitpod.io/#https://github.com/WebXDAO/devprotocol.xyz/pull/205"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

